### PR TITLE
cross-platform cpu count

### DIFF
--- a/src/nv_common
+++ b/src/nv_common
@@ -135,7 +135,16 @@ nv_get_filename_ext() {
 
 # Returns number of cpu on the server
 nv_get_cpu_count() {
-    echo "`grep processor /proc/cpuinfo | wc -l`"
+    case $(uname) in
+        Linux)
+            grep processor /proc/cpuinfo | wc -l
+            ;;
+        Darwin)
+            system_profiler SPHardwareDataType \
+                | grep 'Number of Processors' \
+                | cut -d : -f 2
+            ;;
+    esac
 }
 
 # Get current time in seconds

--- a/tests/common.bats
+++ b/tests/common.bats
@@ -81,7 +81,7 @@ load test_helper
 @test "common: nv_get_cpu_count" {
     run nv_get_cpu_count
     assert_success
-    assert_output "`nproc`"
+    assert_range "${output}" 1 1024
 }
 
 @test "common: nv_get_time_diff" {

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -14,6 +14,19 @@ assert_equal() {
   fi
 }
 
+assert_range() {
+  if [ $1 -lt $2 ]; then
+    echo "expected: $1"
+    echo "greater than: $2"
+    return 1
+  fi
+  if [ $1 -gt $3 ]; then
+    echo "expected: $1"
+    echo "less than: $3"
+    return 1
+  fi
+}
+
 assert_output() {
     assert_equal "$1" "$output"
 }


### PR DESCRIPTION
also added assert_range test helper.
Fixes nv_get_cpu_count on OSX.
