### PR TITLE
Shebang or supported shells

### DIFF
--- a/src/nv
+++ b/src/nv
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # enable debug mode
 if [ "$DEBUG" = "yes" ]; then

--- a/src/nv-commands/activate
+++ b/src/nv-commands/activate
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name=$(nv_get_first_non_opt_value "$@")
     local prompt_enable="yes"

--- a/src/nv-commands/autoon
+++ b/src/nv-commands/autoon
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name=$1
     if [ "$env_name" != "" ]; then

--- a/src/nv-commands/cp
+++ b/src/nv-commands/cp
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name_src=$1
     local env_name_dst=$2

--- a/src/nv-commands/current
+++ b/src/nv-commands/current
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     # deactivate previusly activated environment
     if [ "$NV_USED_ENV" != "" ]; then

--- a/src/nv-commands/deactivate
+++ b/src/nv-commands/deactivate
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name=`nv current`
     local env_name_full=$(nv_get_env_full_path $env_name)

--- a/src/nv-commands/do
+++ b/src/nv-commands/do
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name=$(nv_get_first_non_opt_value "$@")
     local env_name_full=$(nv_get_env_full_path $env_name)

--- a/src/nv-commands/ls
+++ b/src/nv-commands/ls
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local show_meta="yes"
 

--- a/src/nv-commands/ls-cache
+++ b/src/nv-commands/ls-cache
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     for opt in "$@"
     do

--- a/src/nv-commands/ls-commands
+++ b/src/nv-commands/ls-commands
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     # lists all files in the commands directory
     # except hidden and common file

--- a/src/nv-commands/ls-plugins
+++ b/src/nv-commands/ls-plugins
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     for plugin in $(find $(nv_get_plugin_full_path) \
                     -type f \

--- a/src/nv-commands/ls-versions
+++ b/src/nv-commands/ls-versions
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     for par in "$@"
     do

--- a/src/nv-commands/mk
+++ b/src/nv-commands/mk
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name=$(nv_get_first_non_opt_value "$@")
     local save_meta="yes"

--- a/src/nv-commands/mv
+++ b/src/nv-commands/mv
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     local env_name_src=$1
     local env_name_dst=$2

--- a/src/nv-commands/off
+++ b/src/nv-commands/off
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 . $(nv_get_command_full_path)/deactivate
 
 nv_cmd_desc() {

--- a/src/nv-commands/on
+++ b/src/nv-commands/on
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 . $(nv_get_command_full_path)/activate
 
 nv_cmd_desc() {

--- a/src/nv-commands/rm
+++ b/src/nv-commands/rm
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     env_name=""
 

--- a/src/nv-commands/rm-cache
+++ b/src/nv-commands/rm-cache
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 nv_cmd_default() {
     declare delete_entries=""
     declare delete_all="no"

--- a/src/nv-commands/use
+++ b/src/nv-commands/use
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 . $(nv_get_command_full_path)/activate
 
 nv_cmd_desc() {

--- a/src/nv-commands/version
+++ b/src/nv-commands/version
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 NV_VERSION=0.7.1
 
 nv_cmd_default() {

--- a/src/nv-plugins/elixir
+++ b/src/nv-plugins/elixir
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ELX_MIRROR="https://github.com/elixir-lang/elixir"
 

--- a/src/nv-plugins/elixir-prebuilt
+++ b/src/nv-plugins/elixir-prebuilt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # source parent plagin
 . "$(nv_get_plugin_full_path 'elixir')"

--- a/src/nv-plugins/erlang
+++ b/src/nv-plugins/erlang
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Columns count in the version's grid
 plug_list_versions_columns_count=6

--- a/src/nv-plugins/go-prebuilt
+++ b/src/nv-plugins/go-prebuilt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Output lists of versions
 plug_list_versions() {

--- a/src/nv-plugins/haskell
+++ b/src/nv-plugins/haskell
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 GHC_MIRROR=http://www.haskell.org/ghc
 

--- a/src/nv-plugins/julia
+++ b/src/nv-plugins/julia
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 JUL_MIRROR="https://github.com/JuliaLang/julia"
 

--- a/src/nv-plugins/node
+++ b/src/nv-plugins/node
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 NODE_MIRROR="http://nodejs.org/dist"
 

--- a/src/nv-plugins/node-prebuilt
+++ b/src/nv-plugins/node-prebuilt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 NODE_MIRROR="http://nodejs.org/dist"
 

--- a/src/nv-plugins/python
+++ b/src/nv-plugins/python
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 PY_MIRROR="https://www.python.org"
 

--- a/src/nv-plugins/rust
+++ b/src/nv-plugins/rust
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Output lists of versions
 plug_list_versions() {

--- a/src/nv-plugins/rust-prebuilt
+++ b/src/nv-plugins/rust-prebuilt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Output lists of versions
 plug_list_versions() {

--- a/src/nv-plugins/scala
+++ b/src/nv-plugins/scala
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Output lists of versions
 plug_list_versions() {

--- a/src/nv-plugins/stub
+++ b/src/nv-plugins/stub
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 plug_state="disabled"
 

--- a/src/nv_common
+++ b/src/nv_common
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Returns main command name
 nv_cmd_name() {
     echo "nv"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 setup() {
     export NV_PATH="$BATS_TEST_DIRNAME/../src"
     export NV_HOME="$HOME/tmp/envirius-tests"


### PR DESCRIPTION
Current shebangs in source files (`#!/bin/sh`) are wrong.

`#!/bin/sh` means that you're using [POSIX shell](http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html), but you don't (for example: `local`, `[[`, wildcards in tests, arrays - they are bash specified). I don't mean that it's bad - real POSIX shell scripts are rather obscure and making them portable may be [really hard](https://www.gnu.org/software/autoconf/manual/autoconf.html#Portable-Shell). So easiest way is change shebangs to `#!/usr/bin/env bash`.

And users of other shells always could try to run these scripts explicit, eg. `$ zsh nv`.
