### PR TITLE
activate: load .${shell}rc after the nv environment has been set up

### DIFF
--- a/src/nv-commands/activate
+++ b/src/nv-commands/activate
@@ -26,10 +26,10 @@ nv_cmd_default() {
         local curr_shell=$(echo "${SHELL##*/}")
         local TMPFILE=$(mktemp)
 
-        echo ". ~/.${curr_shell}rc" > $TMPFILE
-        echo ". ~/.envirius/nv" >> $TMPFILE
+        echo ". ~/.envirius/nv" > $TMPFILE
         echo "export NV_IN_NEW_SHELL=yes" >> $TMPFILE
         echo "nv activate $@ --same-shell" >> $TMPFILE
+        echo ". ~/.${curr_shell}rc" >> $TMPFILE
         echo "rm -f $TMPFILE" >> $TMPFILE
 
         case $curr_shell in


### PR DESCRIPTION
This enable users to check for the environment variables exported by nv
to further customize their own shell setup (eg. setting a custom prompt
displaying the current environment name).
