### PR TITLE
zsh: fix basic completion

### DIFF
--- a/src/nv
+++ b/src/nv
@@ -133,7 +133,9 @@ fi
 
 if [ "$(nv_is_zsh)" = "yes" ]; then
 
-    compctl -k _$(nv ls-commands | cut -d ' ' -f 3) nv
+    local -a cmds
+    cmds=($(nv ls-commands | cut -d ' ' -f 3))
+    compctl -k cmds nv
 
 fi
 


### PR DESCRIPTION
`compctl -k` is expecting an array of possible completions. To get a
better completion for free, we could also use the bash completion
directly.

Another PR will come with this solution.