### PR TITLE
zsh: use bash completion for zsh through bashcompinit

### DIFF
--- a/src/nv
+++ b/src/nv
@@ -84,8 +84,12 @@ nv() {
     unset SUBACTION
 }
 
+if [ "$(nv_is_zsh)" = "yes" ]; then
+    autoload -U +X bashcompinit && \
+        bashcompinit
+fi
 
-if [ "$(nv_is_bash)" = "yes" ]; then
+if [ "$(nv_is_bash)" = "yes" ] || [ "$(nv_is_zsh),$+functions[bashcompinit]" = "yes,1" ]; then
 
     _nv() {
         cur="${COMP_WORDS[COMP_CWORD]}"
@@ -130,9 +134,7 @@ if [ "$(nv_is_bash)" = "yes" ]; then
 
     complete -F _nv nv
 
-fi
-
-if [ "$(nv_is_zsh)" = "yes" ]; then
+elif [ "$(nv_is_zsh),$+functions[bashcompinit]" = "yes,0" ]; then
 
     local -a cmds
     cmds=($(nv ls-commands | cut -d ' ' -f 3))


### PR DESCRIPTION
This compatibility layer is only present in recent versions of
zsh (circa 2010). If not present, the basic zsh completion will be used
instead.