### PR TITLE
Make mktemp work on OSX

### DIFF
--- a/src/nv-commands/activate
+++ b/src/nv-commands/activate
@@ -24,7 +24,7 @@ nv_cmd_default() {
     # start new shell (if need)
     if [ "$start_new_shell" = "yes" ]; then
         local curr_shell=$(echo "${SHELL##*/}")
-        local TMPFILE=$(mktemp)
+        local TMPFILE=$(mktemp /tmp/envirius-XXXXXX)
 
         echo "export NV_IN_NEW_SHELL=yes" >> $TMPFILE
         echo "export NV_PATH=\"$NV_PATH\"" >> $TMPFILE


### PR DESCRIPTION
The mktemp command in OSX needs a template. Here is an example

mktemp /tmp/foo-XXXXX

I have been testing the fix on OSX and Ubuntu.
