### PR TITLE
updated official download url for get-pip.py

### DIFF
--- a/src/nv-plugins/python
+++ b/src/nv-plugins/python
@@ -31,7 +31,7 @@ plug_install_pip() {
     if [ ! -f "$env_name_full/bin/pip" ]; then
     (
         nv on --same-shell $env_name >/dev/null
-        local get_pip_url="https://raw.github.com/pypa/pip/master/contrib/get-pip.py"
+        local get_pip_url="https://bootstrap.pypa.io/get-pip.py"
         local get_pip=$(nv_download_file $get_pip_url "get-pip.py")
         python $get_pip >/dev/null
     )


### PR DESCRIPTION
Official download link for get-pip.py was changed, and using the original results in an error during creation of a python environment with the 'nv' function.